### PR TITLE
Add real name of the contact person

### DIFF
--- a/tietosuojaseloste.md
+++ b/tietosuojaseloste.md
@@ -4,7 +4,7 @@
 Nimi: Pikaviestin.fi yhteisö
 
 ## 2. Yhteystiedot rekisteriä koskevissa asioissa
-Nimi: Pikaviestin.fi ylläpito
+Nimi: Skyler Mäntysaari
 Sähköposti: tietosuoja@pikaviestin.fi
 
 ## 3. Rekisterin nimi


### PR DESCRIPTION
Add real name of the contact person because Pikaviestin.fi is not a juridical entity.

If it's not Skyler, then feel free to pick any of you.